### PR TITLE
chore(release): 0.0.4-18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 0.0.4-18 (2020-12-20)
+
 ### 0.0.4-17 (2020-12-20)
 
 ### 0.0.4-16 (2020-12-20)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@algotia/core",
-	"version": "0.0.4-17",
+	"version": "0.0.4-18",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"buildAndTest": "npm run build && npm t",
 		"get-version": "echo $npm_package_version",
 		"semantic-release": "semantic-release",
-		"_postinstall": "is-ci || husky install",
+		"postinstall": "is-ci || husky install",
 		"prepublish": "pinst --disable",
 		"postpublish": "pinst --enable"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@algotia/core",
-	"version": "0.0.4-17",
+	"version": "0.0.4-18",
 	"author": "",
 	"license": "ISC",
 	"description": "A technical analysis driven cryptocurrency trading and back-testing platform.",
@@ -19,7 +19,7 @@
 		"buildAndTest": "npm run build && npm t",
 		"get-version": "echo $npm_package_version",
 		"semantic-release": "semantic-release",
-		"postinstall": "is-ci || husky install",
+		"_postinstall": "is-ci || husky install",
 		"prepublish": "pinst --disable",
 		"postpublish": "pinst --enable"
 	},


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [0.0.4-18](https://github.com/Algotia/core/releases/tag/v0.0.4-18)